### PR TITLE
Hide rename link on generated pages

### DIFF
--- a/internal/assets/lastupdate.html.tmpl
+++ b/internal/assets/lastupdate.html.tmpl
@@ -1,5 +1,7 @@
 <p class="bull_lastupdate">
   Page last updated: {{ .Page.ModTime.Format "2006-01-02 15:04:05 Z07:00" }}
+  {{ if (not .Page.IsGenerated) }}
   •
   <a href="{{ .URLBullPrefix }}rename/{{ .Page.URLPath }}">rename</a>
+  {{ end }}
 </p>


### PR DESCRIPTION
Since generated pages can't be renamed (`openat _bull/browse.md: no such file or directory`), don't show the option.